### PR TITLE
Add LinkedIn's ad tracking CDN, licdn.com

### DIFF
--- a/lists/ads.txt
+++ b/lists/ads.txt
@@ -10,3 +10,6 @@
 
 ! 2021-02-21 https://ptable.com
 ptable.com##.Notice
+
+! LinkedIn
+licdn.com

--- a/lists/social.txt
+++ b/lists/social.txt
@@ -42,6 +42,7 @@
 
 ! LinkedIn
 linkedin.com
+licdn.com
 
 ! MySpace
 ||myspace.com^

--- a/lists/social.txt
+++ b/lists/social.txt
@@ -42,7 +42,6 @@
 
 ! LinkedIn
 linkedin.com
-licdn.com
 
 ! MySpace
 ||myspace.com^


### PR DESCRIPTION
LinkedIn uses [this script](https://snap.licdn.com/li.lms-analytics/insight.min.js) to track ad effectiveness. It is considered a tracker by EFF's Privacy Badger, Vivaldi Browser, Brave Browser, and Microsoft Edge Browser.
(I was not sure whether to add a `||` at the start of the line or add a `^` at the end. I also wasn't sure if this was the right file either. Whoops.)